### PR TITLE
Centralize dependent plugin checks.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -158,14 +158,16 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
     };
     plugins.push(deconstContentPlugin);
 
-    var githubStatusPlugin = {
-      id: 'github-status',
-      enabled: true,
-      showStatus: true,
-    };
-    plugins.push(githubStatusPlugin);
+    if (toolbelt.shouldEnableGithubStatusPlugin()) {
+      var githubStatusPlugin = {
+        id: 'github-status',
+        enabled: true,
+        showStatus: true,
+      };
+      plugins.push(githubStatusPlugin);
+    }
 
-    if (toolbelt.config.slackWebhookURL) {
+    if (toolbelt.shouldEnableSlackPlugin()) {
       var slackPlugin = {
         id: 'slack',
         enabled: true,

--- a/lib/toolbelt.js
+++ b/lib/toolbelt.js
@@ -4,12 +4,16 @@ var request = require('request');
 
 var githubProviderPlugin = null;
 var deconstContentPlugin = null;
+var githubStatusPlugin = null;
+var slackPlugin = null;
 
 exports.rememberExtensions = function (context) {
   var extensions = context.loader.extensions;
 
   githubProviderPlugin = extensions.provider.github;
   deconstContentPlugin = extensions.job['deconst-content'];
+  githubStatusPlugin = extensions.job['github-status'];
+  slackPlugin = extensions.job.slack;
 };
 
 var Toolbelt = function (config, job, jobContext, phaseContext) {
@@ -45,6 +49,10 @@ Toolbelt.prototype.workspacePath = function (subpath) {
 
 Toolbelt.prototype.connectToGitHub = function () {
   if (this.githubAPI) return null;
+
+  if (!this.githubProviderPlugin) {
+    return new Error("The GitHub provider plugin is not installed.");
+  }
 
   var githubAccount = this.githubAccount();
 
@@ -88,6 +96,14 @@ Toolbelt.prototype.connectToContentService = function () {
   } else {
     return new Error("Admin API key and content service URL are required to configure new builds.");
   }
+};
+
+Toolbelt.prototype.shouldEnableGithubStatusPlugin = function () {
+  return !! githubStatusPlugin;
+};
+
+Toolbelt.prototype.shouldEnableSlackPlugin = function () {
+  return slackPlugin && this.config.slackWebhookURL;
 };
 
 // Logging messages

--- a/worker.js
+++ b/worker.js
@@ -9,9 +9,6 @@ exports.init = function (config, job, jobContext, callback) {
     deploy: function (phaseContext, cb) {
       var toolbelt = new Toolbelt(config, job, jobContext, phaseContext);
 
-      var err = toolbelt.connectToGitHub();
-      if (err) return cb(err);
-
       entry.prepareControlRepository(toolbelt, function (err) {
         cb(err, true);
       });


### PR DESCRIPTION
This centralizes the checks for dependent plugins in the Toolbelt initialization, and checks them on build initialization. This'll let us only require the GitHub provider if you're actually using `"type": "github"` repositories, for example, and will ensure that we don't set up a build with plugins that don't exist.