### PR TITLE
Grant run access to all users

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -238,24 +238,41 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
   var grantUsersAccess = function (callback) {
     toolbelt.debug("Granting users access to %s.", projectName);
 
-    User.update({}, {
-      $addToSet: {
-        projects: {
-          name: projectName,
-          display_name: projectName,
-          access_level: 1
-        }
-      }
-    }, function (err, count) {
+    User.find({}, function (err, us) {
       if (err) {
-        toolbelt.error("Failed to grant access to the project %s.", projectName, err);
+        toolbelt.error("Unable to list users: %s", err.message);
+        return callback(null);
       }
 
-      if (count < 1) {
-        toolbelt.error("User %s not found to grant admin access to project %s.", toolbelt.user.email, projectName);
-      }
+      var grantUserAccess = function (u, cb) {
+        var alreadyHasAccess = u.projects.some(function (p) {
+          return p.name === projectName;
+        });
 
-      callback(null);
+        if (alreadyHasAccess) {
+          return cb(null);
+        }
+
+        User.update({ _id: u._id }, {
+          $push: {
+            projects: {
+              name: projectName,
+              display_name: projectName,
+              access_level: 1
+            }
+          }
+        }, function (err, count) {
+          if (err) {
+            toolbelt.error("Unable to grant user %s access to project %s", u.email, projectName);
+          } else if (count < 1) {
+            toolbelt.error("No users updated when granting user %s access to project %s", u.email, projectName);
+          }
+
+          cb(null);
+        });
+      };
+
+      async.map(us, grantUserAccess, callback);
     });
   };
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -238,17 +238,17 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
   var grantUsersAccess = function (callback) {
     toolbelt.debug("Granting users access to %s.", projectName);
 
-    User.update({ _id: toolbelt.user._id }, {
-      $push: {
+    User.update({}, {
+      $addToSet: {
         projects: {
           name: projectName,
-          display_name: githubProject.name,
-          access_level: 2
+          display_name: projectName,
+          access_level: 1
         }
       }
     }, function (err, count) {
       if (err) {
-        toolbelt.error("Failed to give %s admin access to the project %s.", toolbelt.user.email, projectName, err);
+        toolbelt.error("Failed to grant access to the project %s.", projectName, err);
       }
 
       if (count < 1) {
@@ -260,8 +260,11 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
   };
 
   checkForExistingProject(function (err, exists) {
-    if (err || exists) return callback(null);
-    if (exists) return callback(null);
+    if (err) return callback(null);
+
+    if (exists) {
+      return grantUsersAccess(callback);
+    }
 
     async.series([
       fetchRepositoryData,


### PR DESCRIPTION
When a new build is autocreated, grant run-level (non-admin, but you can hit the run button) access to all users on the Strider system. Grant access to all users even on previously created projects. This'll save us a lot of fiddling around with one of the more awkward parts of Strider's UI.

Fixes #2.