### PR TITLE
Override npm variables when setting CONTROL_ROOT.

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -137,6 +137,8 @@ var createPreparerContainer = function (state) {
     if (state.dataContainer) {
       params.HostConfig.VolumesFrom = [state.dataContainer];
       params.Env.push("CONTROL_ROOT=" + state.root);
+      params.Env.push("NPM_CONFIG_CACHE=" + path.join(state.root, ".npmcache"));
+      params.Env.push("TMPDIR=" + path.join(state.root, ".tmp"));
     } else {
       var volumeRoot = state.root;
       var containerPath = "/var/control-repo";


### PR DESCRIPTION
Ensure that npm gets writable paths for its cache and temp directory, to sidestep the issue noted in deconst/services#16.