### PR TITLE
Use a non-admin API key.

### DIFF
--- a/lib/content-service.js
+++ b/lib/content-service.js
@@ -17,3 +17,17 @@ exports.issueAPIKey = function (toolbelt, keyName, callback) {
     callback(null, body.apikey);
   });
 };
+
+exports.revokeAPIKey = function (toolbelt, key, callback) {
+  toolbelt.contentAPI.post({
+    url: '/keys/' + encodeURIComponent(key),
+  }, function (err, resp, body) {
+    if (err) return callback(err);
+
+    if (resp.statusCode !== 204) {
+      toolbelt.error('Unable to revoke an API key. Status: %s', resp.status, body);
+
+      return callback(new Error('Unable to revoke API key'));
+    }
+  });
+};

--- a/lib/content-service.js
+++ b/lib/content-service.js
@@ -19,7 +19,7 @@ exports.issueAPIKey = function (toolbelt, keyName, callback) {
 };
 
 exports.revokeAPIKey = function (toolbelt, key, callback) {
-  toolbelt.contentAPI.post({
+  toolbelt.contentAPI.del({
     url: '/keys/' + encodeURIComponent(key),
   }, function (err, resp, body) {
     if (err) return callback(err);
@@ -29,5 +29,7 @@ exports.revokeAPIKey = function (toolbelt, key, callback) {
 
       return callback(new Error('Unable to revoke API key'));
     }
+
+    callback(null);
   });
 };

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -6,6 +6,8 @@ var stream = require('stream');
 var walk = require('walk');
 var Docker = require('dockerode');
 
+var contentService = require('content-service');
+
 var ignored = [
   '.git',
   '.npm',
@@ -93,6 +95,19 @@ var connect = function (toolbelt) {
   docker = new Docker();
 };
 
+var issueAPIKey = function (state) {
+  return function (callback) {
+    state.toolbelt.debug("Issuing temporary API key.");
+
+    contentService.issueAPIkey(state.toolbelt, "strider-auto-control", function (err, key) {
+      if (err) return callback(err);
+
+      state.apikey = key;
+      callback(null);
+    });
+  };
+};
+
 var pullPreparerContainer = function (state) {
   return function (callback) {
     state.toolbelt.debug("Pulling latest preparer container.");
@@ -120,7 +135,7 @@ var createPreparerContainer = function (state) {
 
     var env = [
       "CONTENT_STORE_URL=" + config.contentServiceURL,
-      "CONTENT_STORE_APIKEY=" + config.contentServiceAdminAPIKey,
+      "CONTENT_STORE_APIKEY=" + state.apikey,
       "TRAVIS_PULL_REQUEST=false"
     ];
 
@@ -226,6 +241,14 @@ var removePreparerContainer = function (state) {
   };
 };
 
+var revokeAPIKey = function (state) {
+  return function (callback) {
+    state.toolbelt.debug("Revoking temporary API key.");
+
+    contentService.revokeAPIKey(state.toolbelt, state.apikey, callback);
+  };
+};
+
 var prepare = function (toolbelt, root, callback) {
   connect(toolbelt);
 
@@ -233,16 +256,19 @@ var prepare = function (toolbelt, root, callback) {
     toolbelt: toolbelt,
     root: root,
     dataContainer: process.env.STRIDER_WORKSPACE_CONTAINER,
+    apikey: null,
     container: null
   };
 
   async.series([
+    issueAPIKey(state),
     pullPreparerContainer(state),
     createPreparerContainer(state),
     startPreparerContainer(state),
     preparerContainerLogs(state),
     waitForCompletion(state),
-    removePreparerContainer(state)
+    removePreparerContainer(state),
+    revokeAPIKey(state)
   ], function (err) {
     if (err) {
       toolbelt.error("Error running the asset preparer.", err);

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -6,7 +6,7 @@ var stream = require('stream');
 var walk = require('walk');
 var Docker = require('dockerode');
 
-var contentService = require('content-service');
+var contentService = require('./content-service');
 
 var ignored = [
   '.git',
@@ -99,7 +99,7 @@ var issueAPIKey = function (state) {
   return function (callback) {
     state.toolbelt.debug("Issuing temporary API key.");
 
-    contentService.issueAPIkey(state.toolbelt, "strider-auto-control", function (err, key) {
+    contentService.issueAPIKey(state.toolbelt, "strider-auto-control", function (err, key) {
       if (err) return callback(err);
 
       state.apikey = key;


### PR DESCRIPTION
Using the admin API key for the asset preparer is not ideal; it increases the risk of leaking the admin API key by getting malicious PRs. (You'd have to actually merge them, but still.) Issue a temporary API key and send that to the asset preparer instead.

Related to deconst/services#16.