### PR TITLE
Bootstrap content PR builds

### DIFF
--- a/config/config.html
+++ b/config/config.html
@@ -22,6 +22,24 @@
   </p>
   <input type="text" id="slack-webhook-url" ng-model="config.slackWebhookURL" ng-blur="save()" placeholder="https://hook.slack/services/etc">
 
+  <label for="staging-presenter-url" class="bold-label">Staging Presenter URL</label>
+  <p class="help-text">
+    Base URL of the staging server.
+  </p>
+  <input type="text" id="staging-presenter-url" ng-model="config.stagingPresenterURL" ng-blur="save()" placeholder="https://staging...">
+
+  <label for="staging-content-service-url" class="bold-label">Staging Content Service URL</label>
+  <p class="help-text">
+    Base URL of the staging content service for this Deconst cluster.
+  </p>
+  <input type="text" id="staging-content-service-url" ng-model="config.stagingContentServiceURL" ng-blur="save()" placeholder="https://content.staging...">
+
+  <label for="staging-admin-key" class="bold-label">Staging Admin API Key</label>
+  <p class="help-text">
+    API key issued by the staging content service. Must have admin rights.
+  </p>
+  <input type="password" id="staging-admin-key" ng-model="config.stagingContentServiceAdminAPIKey" ng-blur="save()">
+
   <label for="slack-channel" class="bold-label">Slack Channel</label>
   <p class="help-text">
     <em>Optional.</em> Channel to use for Slack notifications.

--- a/config/config.html
+++ b/config/config.html
@@ -22,6 +22,12 @@
   </p>
   <input type="text" id="slack-webhook-url" ng-model="config.slackWebhookURL" ng-blur="save()" placeholder="https://hook.slack/services/etc">
 
+  <label for="slack-channel" class="bold-label">Slack Channel</label>
+  <p class="help-text">
+    <em>Optional.</em> Channel to use for Slack notifications.
+  </p>
+  <input type="text" id="slack-channel" ng-model="config.slackChannel" ng-blur="save()" placeholder="#general">
+
   <label for="staging-presenter-url" class="bold-label">Staging Presenter URL</label>
   <p class="help-text">
     Base URL of the staging server.
@@ -39,12 +45,6 @@
     API key issued by the staging content service. Must have admin rights.
   </p>
   <input type="password" id="staging-admin-key" ng-model="config.stagingContentServiceAdminAPIKey" ng-blur="save()">
-
-  <label for="slack-channel" class="bold-label">Slack Channel</label>
-  <p class="help-text">
-    <em>Optional.</em> Channel to use for Slack notifications.
-  </p>
-  <input type="text" id="slack-channel" ng-model="config.slackChannel" ng-blur="save()" placeholder="#general">
 
   <label class="bold-label inline-label">
     <input type="checkbox" class="inline-checkbox" ng-model="config.verbose" ng-change="save()"> Verbose

--- a/lib/build.js
+++ b/lib/build.js
@@ -139,7 +139,8 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
         auth: { type: 'https' },
         repo: githubProject.repo,
         owner: githubProject.owner.login,
-        url: githubProject.clone_url
+        url: githubProject.clone_url,
+        pull_requests: 'all'
       }
     };
 
@@ -156,8 +157,7 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
         stagingPresenterURL: toolbelt.config.stagingPresenterURL,
         stagingContentServiceURL: toolbelt.config.stagingContentServiceURL,
         stagingContentServiceAdminAPIKey: toolbelt.config.stagingContentServiceAdminAPIKey,
-        verbose: false,
-        pull_requests: 'all'
+        verbose: false
       }
     };
     plugins.push(deconstContentPlugin);

--- a/lib/build.js
+++ b/lib/build.js
@@ -153,6 +153,9 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
         contentServiceURL: toolbelt.config.contentServiceURL,
         contentServiceTLSVerify: toolbelt.config.contentServiceTLSVerify,
         contentServiceAPIKey: contentServiceAPIKey,
+        stagingPresenterURL: toolbelt.config.stagingPresenterURL,
+        stagingContentServiceURL: toolbelt.config.stagingContentServiceURL,
+        stagingContentServiceAdminAPIKey: toolbelt.config.stagingContentServiceAdminAPIKey,
         verbose: false,
         pull_requests: 'all'
       }

--- a/lib/build.js
+++ b/lib/build.js
@@ -153,7 +153,8 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
         contentServiceURL: toolbelt.config.contentServiceURL,
         contentServiceTLSVerify: toolbelt.config.contentServiceTLSVerify,
         contentServiceAPIKey: contentServiceAPIKey,
-        verbose: false
+        verbose: false,
+        pull_requests: 'all'
       }
     };
     plugins.push(deconstContentPlugin);

--- a/webapp.js
+++ b/webapp.js
@@ -12,6 +12,15 @@ module.exports = {
       type: Boolean,
       default: true
     },
+    stagingPresenterURL: {
+      type: String
+    },
+    stagingContentServiceURL: {
+      type: String
+    },
+    stagingContentServiceAdminAPIKey: {
+      type: String
+    },
     slackWebhookURL: {
       type: String
     },


### PR DESCRIPTION
When automatically creating builds for the content repository, enable pull-request builds and pass along the staging endpoints and configuration.

Fixes #15.