### PR TITLE
Configure builds from multiple, non-master branches

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1,6 +1,7 @@
 var util = require('util');
 var async = require('async');
 var keypair = require('ssh-keypair');
+var _ = require('lodash');
 
 var github = require('./github');
 var contentService = require('./content-service');
@@ -37,6 +38,8 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
 
     return callback(null);
   }
+
+  var deploymentBranches = repository.branches || ['master'];
 
   var contentError = toolbelt.connectToContentService();
   var githubError = toolbelt.connectToGitHub();
@@ -190,6 +193,36 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
       plugins.push(slackPlugin);
     }
 
+    var branches = [];
+
+    if (!_.includes(deploymentBranches, 'master')) {
+      branches.push({
+        name: 'master',
+        active: false,
+        deploy_on_green: false,
+        mirror_master: false,
+        pubkey: publicKey,
+        privkey: privateKey,
+        plugins: plugins,
+        runner: { id: 'simple-runner', config: { pty: false } }
+      });
+    }
+
+    for (var i = 0; i < deploymentBranches.length; i++) {
+      var branchName = deploymentBranches[i];
+
+      branches.push({
+        name: branchName,
+        active: true,
+        deploy_on_green: true,
+        mirror_master: false,
+        pubkey: publicKey,
+        privkey: privateKey,
+        plugins: plugins,
+        runner: { id: 'simple-runner', config: { pty: false } }
+      });
+    }
+
     var projectAttrs = {
       name: projectName,
       display_name: githubProject.name,
@@ -198,22 +231,7 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
       prefetch_config: false,
       creator: toolbelt.user._id,
       provider: provider,
-      branches: [
-        {
-          name: 'master',
-          active: true,
-          mirror_master: false,
-          deploy_on_green: true,
-          pubkey: publicKey,
-          privkey: privateKey,
-          plugins: plugins,
-          runner: { id: 'simple-runner', config: { pty: false } }
-        },
-        {
-          name: '*',
-          mirror_master: true
-        }
-      ]
+      branches: branches
     };
 
     toolbelt.debug("Setting up GitHub provider plugin for %s.", projectName);

--- a/lib/build.js
+++ b/lib/build.js
@@ -198,7 +198,7 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
     if (!_.includes(deploymentBranches, 'master')) {
       branches.push({
         name: 'master',
-        active: false,
+        active: true,
         deploy_on_green: false,
         mirror_master: false,
         pubkey: publicKey,
@@ -220,6 +220,13 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
         privkey: privateKey,
         plugins: plugins,
         runner: { id: 'simple-runner', config: { pty: false } }
+      });
+    }
+
+    if (!_.includes(deploymentBranches, '*')) {
+      branches.push({
+        name: '*',
+        mirror_master: true
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "dockerode": "^2.2.9",
+    "lodash": "^4.6.1",
     "request": "^2.67.0",
     "ssh-keypair": "^2.0.0",
     "walk": "^2.3.9"


### PR DESCRIPTION
If a `branches` key is present in the content repository list entry, use it as a list of branch patterns that should be deployed from.

Always set up `master` and `*` (first and last, respectively) to be active so that pull requests to _any_ branches will be built properly. `master`'s build should be active but have `deploy_on_green` disabled unless it's explicitly included.

Fixes #14.