### PR TITLE
Configure project with correct GitHub owner

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -141,7 +141,7 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
       config: {
         auth: { type: 'https' },
         repo: githubProject.repo,
-        owner: githubProject.owner.login,
+        owner: githubProject.owner,
         url: githubProject.clone_url,
         pull_requests: 'all'
       }


### PR DESCRIPTION
This was causing automatically created Strider builds to not set GitHub commit statuses correctly.