### PR TITLE
Disable star builds.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -210,13 +210,6 @@ var createGitHubBuild = function (toolbelt, repository, callback) {
       })
     }
 
-    if (!_.includes(deploymentBranches, '*')) {
-      branches.push({
-        name: '*',
-        mirror_master: true
-      })
-    }
-
     var projectAttrs = {
       name: projectName,
       display_name: githubProject.full_name,


### PR DESCRIPTION
Don't install a `*` build. Pull requests to non-live branches will no longer get preview links, which is a bit unfortunate. That's uncommon though, so I think it's worth it.

Fixes #24.